### PR TITLE
Ttt5 2233 temporarily remove news email

### DIFF
--- a/playwright/tests/email_regression/news_contact.js
+++ b/playwright/tests/email_regression/news_contact.js
@@ -9,7 +9,7 @@ test.use({ storageState: 'tests/state.json' });
 // ** WHEN TOM JONES?JOHN GIBBS CAN BE EMAILED IN THIS WAY
 //    WE NEED TO ADD THE .SPEC. BACK INTO THE FILE TO
 //    CONTINUE TESTING THIS PART OF THE APP AND REMOVE
-//    THIS COMMENT
+//    THIS COMMENT **
 
 test("Contact Messaging From Event", async ({ page }) => {
   function Name_Alpha_Numeric() {

--- a/playwright/tests/email_regression/news_contact.js
+++ b/playwright/tests/email_regression/news_contact.js
@@ -1,0 +1,98 @@
+const config = require('../../playwright.config.js');
+const { test, expect } = require('@playwright/test');
+const assert = require('chai').assert;
+// const Mailosaur = require('mailosaur');
+require('dotenv').config();
+
+test.use({ storageState: 'tests/state.json' });
+
+// ** WHEN TOM JONES?JOHN GIBBS CAN BE EMAILED IN THIS WAY
+//    WE NEED TO ADD THE .SPEC. BACK INTO THE FILE TO
+//    CONTINUE TESTING THIS PART OF THE APP AND REMOVE
+//    THIS COMMENT
+
+test("Contact Messaging From Event", async ({ page }) => {
+  function Name_Alpha_Numeric() {
+    var text = "";
+    var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    for (var i = 0; i < 10; i++)
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+    return text;
+  }
+
+  // const apiKey = process.env.MAILOSAUR_API_KEY;
+  // const mailosaur = new Mailosaur(apiKey);
+
+  // const serverId = process.env.MAILOSAUR_SERVER;
+
+  await page.goto(config.use.baseURL + "home");
+
+  await expect(page).toHaveURL(config.use.baseURL + 'home');
+  // Click [data-test="newsNavButton"]
+  await page.click('[data-test="newsNavButton"]');
+  await expect(page).toHaveURL('https://staging.talentticker.ai/news');
+  // Click [placeholder="Search"]
+  await page.click('[placeholder="Search"]');
+  // Fill [placeholder="Search"]
+  await page.fill('[placeholder="Search"]', 'Talent Ticker');
+  // Click text=Talent Ticker
+  await page.click('text=Talent Ticker');
+  // Click [data-test="searchSubmit"]
+  await page.click('[data-test="searchSubmit"]');
+  // Click text=Talent Ticker expands with opening of New York officeTalent TickerNew York, NYPr
+  await page.click('text=Talent Ticker expands with opening of New York officeTalent TickerNew York, NYPr');
+
+  // Click [data-testid="news-page"] >> text=Clear all
+  await page.click('[data-testid="news-page"] >> text=Clear all');
+
+  // Fill [placeholder="Search\ by\ name\,\ role\ or\ location"]
+  await page.fill('[placeholder="Search\\ by\\ name\\,\\ role\\ or\\ location"]', 'Senior Sales Representative');
+  // Click text=“Tom Jones”
+  await page.click('text=“Senior Sales Representative”');
+  // Check input[type="checkbox"]
+  await page.check('input[type="checkbox"]');
+  // Click text=emailMessage (1)
+  await page.click('text=emailMessage (1)');
+
+  const randomName = Name_Alpha_Numeric();
+  // Fill [aria-label="subject"]
+  await page.fill('[aria-label="subject"]', randomName);
+  // Click text=Send Message
+  await page.click('text=Send Message');
+
+  await expect(
+    page.locator('[data-testid="message-send-success"]')
+  ).toContainText("Message successfully sent");
+
+  // Click button:has-text("close")
+  await page.click('[data-testid="close-drawer-button"]');
+
+  await page.click('[aria-label="Close"]');
+  
+  // Click [data-test="contatcsNavButton"]
+  await page.click('[data-test="contatcsNavButton"]');
+  await expect(page).toHaveURL('https://staging.talentticker.ai/outbox');
+
+  expect(await page.innerText('h1')).toContain("Outbox");
+
+  await page.reload();
+
+  expect(await page.innerText('h1')).toContain("Outbox");
+
+  await expect(
+    page.locator(':nth-match(span[class="subject"], 1)')
+  ).toContainText(randomName);
+
+  // Once we have a test user that we can check in Mailosaur (i.e. same as messaging.spec) uncomment below when user has been switched
+  // so we can check for mail delivery
+  
+  // // Search for the email
+  // const email = await mailosaur.messages.get(serverId, {
+  //   sentTo: process.env.TEST_EMAIL
+  // });
+
+  // assert.equal(email.subject, randomName);
+
+  });


### PR DESCRIPTION
Until we can email out to Tom Jones again or can associate the test user with TT/Selligence gets a news story in the feed. Forgot to push this up yesterday