### PR TITLE
Upping the workers on CI

### DIFF
--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -3,6 +3,8 @@ import { type PlaywrightTestConfig, devices } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
+  // Limit the number of workers on CI, use default locally
+  workers: process.env.CI ? 3 : undefined,
   globalSetup: require.resolve('./tests/global-setup'),
   use: {
     baseURL: "https://staging.talentticker.ai/",


### PR DESCRIPTION
Seems to be only using 1 worker at the moment which is slowing down the tests. They all use different accounts for things like schedules and sequences so more workers shouldn't be a problem.